### PR TITLE
Fix order dependent tests in `HandlerTest`

### DIFF
--- a/handler/src/main/java/com/networknt/handler/Handler.java
+++ b/handler/src/main/java/com/networknt/handler/Handler.java
@@ -540,6 +540,7 @@ public class Handler {
         Handler.configName = configName;
         config = (HandlerConfig) Config.getInstance().getJsonObjectConfig(configName, HandlerConfig.class);
         initHandlers();
+        initChains();
         initPaths();
     }
 

--- a/handler/src/test/java/com/networknt/handler/HandlerTest.java
+++ b/handler/src/test/java/com/networknt/handler/HandlerTest.java
@@ -24,6 +24,7 @@ import io.undertow.util.HttpString;
 import io.undertow.util.Methods;
 import io.undertow.util.PathTemplateMatcher;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 
 import java.util.Arrays;
@@ -31,6 +32,11 @@ import java.util.List;
 import java.util.Map;
 
 public class HandlerTest {
+
+    @Before()
+    public void setUp() throws Exception {
+        Handler.setConfig("handler");
+    }
 
     @Test
     public void validClassNameWithoutAt_split_returnsCorrect() throws Exception {

--- a/handler/src/test/java/com/networknt/handler/HandlerTest.java
+++ b/handler/src/test/java/com/networknt/handler/HandlerTest.java
@@ -35,6 +35,7 @@ public class HandlerTest {
 
     @Before()
     public void setUp() throws Exception {
+        // Resetting HandlerConfig to default Config before each test run
         Handler.setConfig("handler");
     }
 


### PR DESCRIPTION
#### Issue
- If `validConfig_init_handlersCreated()` is run after `invalidMethod_init_throws()`, we face the following issue
```
java.lang.RuntimeException: Bad paths element in invalid-method config [ Invalid HTTP method: hello ]
	at com.networknt.handler.config.PathChain.validate(PathChain.java:94)
	at com.networknt.handler.Handler.initPaths(Handler.java:127)
	at com.networknt.handler.Handler.init(Handler.java:75)
	at com.networknt.handler.HandlerTest.test02_validConfig_init_handlersCreated(HandlerTest.java:57)
```
- Since JUnit 4 doesn't guarantee the order of test executions by default, JUnit could execute `validConfig_init_handlersCreated()` after `invalidMethod_init_throws()` resulting in the above error.

#### Root Cause
- The test `invalidMethod_init_throws()` sets the `HandlerConfig` to `invalid-method` at https://github.com/networknt/light-4j/blob/7152f180fe4eef1e991b5618d61ca199c3d0de77/handler/src/test/java/com/networknt/handler/HandlerTest.java#L121
- When the test `validConfig_init_handlersCreated()` is run after the above step, the `HandlerConfig` is no longer the default value `handler`
- Initiating the `HandlerTest.validConfig_init_handlersCreated()` with `invalid-method` configuration causes the above issue. 

#### Solution
- Resetting the `HandlerConfig` to default value before each test run will ensure that the unit tests are run with the correct `HandlerConfig`
- This can be done by using the Junit's `@Before` annotation, where the configuration is set to default value through `Handler.setConfig('handler')`
- We need to add `initChain()` because `initPath()`  in `setConfig`, which expects handler or chain to already be created.