### PR TITLE
Fixed order dependent tests in CorrelationHandlerTest by reloading CorrelationConfig

### DIFF
--- a/correlation/src/test/java/com/networknt/correlation/CorrelationHandlerTest.java
+++ b/correlation/src/test/java/com/networknt/correlation/CorrelationHandlerTest.java
@@ -178,6 +178,10 @@ public class CorrelationHandlerTest {
         } finally {
             IoUtils.safeClose(connection);
         }
+
+        // set the autogen of the correlation ID to default value
+        CorrelationHandler.config.setAutogenCorrelationID(true);
+
         int statusCode = reference.get().getResponseCode();
         String body = reference.get().getAttachment(Http2Client.RESPONSE_BODY);
         Assert.assertEquals(200, statusCode);


### PR DESCRIPTION
#### Issue
- If `testGetWithoutTid()` is run after `testGetWithoutTidNoAutogen()`, we face the following issue
```
java.lang.AssertionError: 
Expected :200
Actual   :500
	at org.junit.Assert.fail(Assert.java:89)
	at org.junit.Assert.failNotEquals(Assert.java:835)
	at org.junit.Assert.assertEquals(Assert.java:647)
	at org.junit.Assert.assertEquals(Assert.java:633)
	at com.networknt.correlation.CorrelationHandlerTest.test02_testGetWithoutTid(CorrelationHandlerTest.java:158)
```
- Since JUnit 4 doesn't guarantee the order of test executions by default, JUnit could execute `validConfig_init_handlersCreated()` after `invalidMethod_init_throws()` resulting in the above error.


#### Root Cause
- The test `testGetWithoutTidNoAutogen()` sets the `autogenCorrelationID` to `false` at https://github.com/networknt/light-4j/blob/7152f180fe4eef1e991b5618d61ca199c3d0de77/correlation/src/test/java/com/networknt/correlation/CorrelationHandlerTest.java#L159
- When the test `testGetWithoutTid()` is run after the above step, the following code is not executed because of the polluted `autogenCorrelationID`
https://github.com/networknt/light-4j/blob/7152f180fe4eef1e991b5618d61ca199c3d0de77/correlation/src/main/java/com/networknt/correlation/CorrelationHandler.java#L68-L75
- Since the UUID is not generated and not set in the request handler, the request given from the test `testGetWithoutTid()` results in a 5xx server error

#### Solution
- Resetting the `CorrelationHandler.config` to default value before each test run will ensure that the unit tests are run with the correct config value
- This can be done by using the Junit's `@Before` annotation, where the configuration is set to default value through `CorrelationHandler.config = CorrelationConfig.load();`